### PR TITLE
GDCC/21- Handle path and file validation

### DIFF
--- a/src/css/dvwebloader.css
+++ b/src/css/dvwebloader.css
@@ -45,6 +45,10 @@ label {
     background-color: beige;
     padding: 10px;
 }
+.warn {
+   background-color: bisque;
+    padding: 10px;
+}
 .file-exists {
     background-color: lightblue;
 }
@@ -66,4 +70,8 @@ h1 {
     text-align: center;
     width: 58%;
     display:inline-block;
+}
+.badchars {
+   background-color: bisque;
+    padding: 10px;
 }

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -668,7 +668,7 @@ function queueFileForDirectUpload(file) {
     console.log("Original Path: " + origPath);
     //Remove filename part
     let path =origPath.substring(0, origPath.length - file.name.length);
-    let badPath = (path.match(/^[a-zA-Z0-9_\-\.\\\/ ]*$/)===null);
+    let badPath = (path.match(/^[\w\d_\-\.\\\/ ]*$/)===null);
     if(badPath) {
       if($('.warn').length==0) {
         addMessage('warn', 'msgRequiredPathOrFileNameChange');
@@ -709,7 +709,7 @@ function queueFileForDirectUpload(file) {
     }
     row.append($('<input/>').prop('type', 'checkbox').prop('id', 'file_' + fileBlock.children().length).prop('checked', send));
     let fnameElement = $('<div/>').addClass('ui-fileupload-filename').text(origPath);
-    if(badChars) {
+    if(badPath || badChars) {
       fnameElement.addClass('badchars');
     }
     row.append(fnameElement)

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -668,7 +668,7 @@ function queueFileForDirectUpload(file) {
     console.log("Original Path: " + origPath);
     //Remove filename part
     let path =origPath.substring(0, origPath.length - file.name.length);
-    let badPath = (path.match(/^[a-zA-Z0-9_\-.\\\/ ]*$/)===null);
+    let badPath = (path.match(/^[a-zA-Z0-9_\-\.\\\/ ]*$/)===null);
     if(badPath) {
       if($('.warn').length==0) {
         addMessage('warn', 'msgRequiredPathOrFileNameChange');

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -665,7 +665,7 @@ function queueFileForDirectUpload(file) {
     var fUpload = new fileUpload(file);
     let send = true;
     let origPath = file.webkitRelativePath.substring(file.webkitRelativePath.indexOf('/') + 1);
-    console.log("Original Path: " + origPath);
+    
     //Remove filename part
     let path =origPath.substring(0, origPath.length - file.name.length);
     let badPath = (path.match(/^[\w\d_\-\.\\\/ ]*$/)===null);
@@ -678,7 +678,7 @@ function queueFileForDirectUpload(file) {
     }
     //Re-Add filename, munge filename if needed
     path=path.concat(file.name.replace(/[\/:*?|;#]/g,'_'));
-    console.log("Final Path: " + path);
+    
     //Now check versus existing files
     if (path in existingFiles) {
         send = false;

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -668,7 +668,8 @@ function queueFileForDirectUpload(file) {
     var fUpload = new fileUpload(file);
     let send = true;
     let origPath = file.webkitRelativePath.substring(file.webkitRelativePath.indexOf('/') + 1);
-    console.log(path);
+    console.log("Original Path: " + origPath);
+    //Remove filename part
     let path =origPath.substring(0, origPath.length - file.name.length);
     let badPath = (path.match(/^[a-zA-Z0-9_\-.\\\/ ]*$/)===null);
     if(badPath) {
@@ -677,9 +678,10 @@ function queueFileForDirectUpload(file) {
       }
       //Munge path according to rules
       path = path.replace(/[^\w\d_\\.\\\/ ]+/g,'_');
-      //Munge filename if needed
-      path=path.concat(file.name.replace(/[\/:*?|;#]/g,'_'));
     }
+    //Re-Add filename, munge filename if needed
+    path=path.concat(file.name.replace(/[\/:*?|;#]/g,'_'));
+    console.log("Final Path: " + path);
     //Now check versus existing files
     if (path in existingFiles) {
         send = false;

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -188,6 +188,10 @@ function initSpanTxt(htmlId, key) {
 function addMessage(type, key) {
     $('#messages').html('').append($('<div/>').addClass(type).text(getLocalizedString(dvLocale, key)));
 }
+function appendMessage(type, text) {
+    $('#messages').append($('<div/>').addClass(type).text(text));
+}
+
 async function populatePageMetadata(data) {
     var mdFields = data.metadataBlocks.citation.fields;
     var title = "";
@@ -686,8 +690,18 @@ function queueFileForDirectUpload(file) {
     if (!send) {
         row.addClass('file-exists');
     }
-    row.append($('<input/>').prop('type', 'checkbox').prop('id', 'file_' + fileBlock.children().length).prop('checked', send))
-        .append($('<div/>').addClass('ui-fileupload-filename').text(path))
+    let badChars = !(fUpload.file.name.match(/[[\/:*?|;#]/)===null);
+    if(badChars) {
+      if($('.warn').length==0) {
+        appendMessage('warn','The highlighted file(s) below contain one or more disallowed characters (/;:|?*#) in their filename. Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.');
+      }
+    }
+    row.append($('<input/>').prop('type', 'checkbox').prop('id', 'file_' + fileBlock.children().length).prop('checked', send));
+    let fnameElement = $('<div/>').addClass('ui-fileupload-filename').text(path);
+    if(badChars) {
+      fnameElement.addClass('badchars');
+    }
+    row.append(fnameElement)
         .append($('<div/>').text(file.size)).append($('<div/>').addClass('ui - fileupload - progress'))
         .append($('<div/>').addClass('ui - fileupload - cancel'));
     console.log('adding click handler for file_' + fileBlock.children().length);
@@ -824,7 +838,7 @@ async function directUploadFinished() {
                     console.log(fup.file.webkitRelativePath + ' : ' + fup.storageId);
                     let entry = {};
                     entry.storageIdentifier = fup.storageId;
-                    entry.fileName = fup.file.name;
+                    entry.fileName = fup.file.name.replace(/[\/:*?|;#]/g,'_');
                     let path = fup.file.webkitRelativePath;
                     console.log(path);
                     path = path.substring(path.indexOf('/'), path.lastIndexOf('/'));

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -188,9 +188,6 @@ function initSpanTxt(htmlId, key) {
 function addMessage(type, key) {
     $('#messages').html('').append($('<div/>').addClass(type).text(getLocalizedString(dvLocale, key)));
 }
-function appendMessage(type, text) {
-    $('#messages').append($('<div/>').addClass(type).text(text));
-}
 
 async function populatePageMetadata(data) {
     var mdFields = data.metadataBlocks.citation.fields;
@@ -674,7 +671,7 @@ function queueFileForDirectUpload(file) {
     let badPath = (path.match(/^[a-zA-Z0-9_\-.\\\/ ]*$/)===null);
     if(badPath) {
       if($('.warn').length==0) {
-        addMessage('warn', 'msgRequiredFileOrPathNameChange');
+        addMessage('warn', 'msgRequiredPathOrFileNameChange');
       }
       //Munge path according to rules
       path = path.replace(/[^\w\d_\\.\\\/ ]+/g,'_');
@@ -707,7 +704,7 @@ function queueFileForDirectUpload(file) {
     let badChars = !(fUpload.file.name.match(/[[\/:*?|;#]/)===null);
     if(badChars) {
       if($('.warn').length==0) {
-        appendMessage('warn','The highlighted file(s) below contain one or more disallowed characters (/;:|?*#) in their filename. Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.');
+          addMessage('warn', 'msgRequiredPathOrFileNameChange');
       }
     }
     row.append($('<input/>').prop('type', 'checkbox').prop('id', 'file_' + fileBlock.children().length).prop('checked', send));

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -685,7 +685,7 @@ function queueFileForDirectUpload(file) {
     } else if (removeExtension(path) in convertedFileNameMap) {
         send = false;
     }
-    rawFileMap[path] = file;
+    rawFileMap[origPath] = file;
     let i = rawFileMap.length;
     //startUploads();
     if (send) {

--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -15,7 +15,7 @@ const translations = {
         msgNoFile: "No files to upload. Check some files, or refresh to start over.",
         msgUploadCompleteRegistering: "Uploads to S3 complete. Now registering all files with the dataset. This may take some time for large numbers of files.",
         msgUploadComplete: "Upload complete, all files in dataset. Close this window and refresh your dataset page to see the uploaded files.",
-        msgRequiredFileNameChange: "The highlighted file(s) below contain one or more disallowed characters (/;:|?*#) in their filename. Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.",
+        msgRequiredPatOrFileNameChange: "The highlighted path/file(s) below contain one or more disallowed characters (paths can only contain a-Z, 0-9, '_', '-', '.', '\', '/' and ' ', and filenames cannot contain any of /;:|?*#). Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.",
     },
     fr: {
         title: "Envoi d'un dossier",
@@ -32,7 +32,7 @@ const translations = {
         msgNoFile: "Aucun fichier à envoyer. Cochez certains fichiers ou rafraîchissez la page pour recommencer.",
         msgUploadCompleteRegistering: "Envois vers S3 terminés. Enregistrement de tous les fichiers en cours dans le jeu de données. Cela peut prendre du temps pour un grand nombre de fichiers.",
         msgUploadComplete: "Envoi terminé, tous les fichiers sont dans le jeu de données. Fermez cette fenêtre et rafraîchissez la page de votre jeu de données pour voir les fichiers envoyés.",
-        msgRequiredFileNameChange: "Le ou les fichiers en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (/;:|?*#) dans leur nom de fichier. Les caractères non autorisés seront remplacés par un trait de soulignement (_) si le(s) fichier(s) sont téléchargés.",
+        msgRequiredFileNameChange: "Les chemins/noms de fichiers en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (les chemins ne peuvent contenir que a-Z, 0-9, '_', '-', '.', '\', '/' et ' ', et les noms de fichiers ne peuvent contenir aucun des éléments suivants : /;:|?*#). Les caractères non autorisés seront remplacés par un trait de soulignement (_) si le(s) fichier(s) sont téléchargés.",
     },
 };
 

--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -15,6 +15,7 @@ const translations = {
         msgNoFile: "No files to upload. Check some files, or refresh to start over.",
         msgUploadCompleteRegistering: "Uploads to S3 complete. Now registering all files with the dataset. This may take some time for large numbers of files.",
         msgUploadComplete: "Upload complete, all files in dataset. Close this window and refresh your dataset page to see the uploaded files.",
+        msgRequiredFileNameChange: "The highlighted file(s) below contain one or more disallowed characters (/;:|?*#) in their filename. Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.",
     },
     fr: {
         title: "Envoi d'un dossier",
@@ -31,6 +32,7 @@ const translations = {
         msgNoFile: "Aucun fichier à envoyer. Cochez certains fichiers ou rafraîchissez la page pour recommencer.",
         msgUploadCompleteRegistering: "Envois vers S3 terminés. Enregistrement de tous les fichiers en cours dans le jeu de données. Cela peut prendre du temps pour un grand nombre de fichiers.",
         msgUploadComplete: "Envoi terminé, tous les fichiers sont dans le jeu de données. Fermez cette fenêtre et rafraîchissez la page de votre jeu de données pour voir les fichiers envoyés.",
+        msgRequiredFileNameChange: "Le ou les fichiers en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (/;:|?*#) dans leur nom de fichier. Les caractères non autorisés seront remplacés par un trait de soulignement (_) si le(s) fichier(s) sont téléchargés.",
     },
 };
 

--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -15,7 +15,7 @@ const translations = {
         msgNoFile: "No files to upload. Check some files, or refresh to start over.",
         msgUploadCompleteRegistering: "Uploads to S3 complete. Now registering all files with the dataset. This may take some time for large numbers of files.",
         msgUploadComplete: "Upload complete, all files in dataset. Close this window and refresh your dataset page to see the uploaded files.",
-        msgRequiredPathOrFileNameChange: "The highlighted path/file(s) below contain one or more disallowed characters (paths can only contain a-Z, 0-9, '_', '-', '.', '\', '/' and ' ', and filenames cannot contain any of /;:|?*#). Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.",
+        msgRequiredPathOrFileNameChange: "The highlighted path/file(s) below contain one or more disallowed characters (paths can only contain a-Z, 0-9, '_', '-', '.', '\', '/' and ' ', and filenames cannot contain any of '/;:|?*#' ). Disallowed characters will be replaced by an underscore ('_') if the file(s) are uploaded.",
     },
     fr: {
         title: "Envoi d'un dossier",
@@ -32,7 +32,7 @@ const translations = {
         msgNoFile: "Aucun fichier à envoyer. Cochez certains fichiers ou rafraîchissez la page pour recommencer.",
         msgUploadCompleteRegistering: "Envois vers S3 terminés. Enregistrement de tous les fichiers en cours dans le jeu de données. Cela peut prendre du temps pour un grand nombre de fichiers.",
         msgUploadComplete: "Envoi terminé, tous les fichiers sont dans le jeu de données. Fermez cette fenêtre et rafraîchissez la page de votre jeu de données pour voir les fichiers envoyés.",
-        msgRequiredPathOrFileNameChange: "Les chemins/noms de fichiers en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (les chemins ne peuvent contenir que a-Z, 0-9, '_', '-', '.', '\', '/' et ' ', et les noms de fichiers ne peuvent contenir aucun des éléments suivants : /;:|?*#). Les caractères non autorisés seront remplacés par un trait de soulignement (_) si le(s) fichier(s) sont téléchargés.",
+        msgRequiredPathOrFileNameChange: "Le(s) chemin(s) en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (les chemins ne peuvent contenir que a-Z, 0-9, '_', '-', '.', '\', '/' et ' ', et les noms de fichiers ne peuvent contenir aucun des éléments '/;:|?*#' ). Les caractères non autorisés seront remplacés par un trait de soulignement (« _ ») si le(s) fichier(s) sont téléchargés.",
     },
 };
 

--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -15,7 +15,7 @@ const translations = {
         msgNoFile: "No files to upload. Check some files, or refresh to start over.",
         msgUploadCompleteRegistering: "Uploads to S3 complete. Now registering all files with the dataset. This may take some time for large numbers of files.",
         msgUploadComplete: "Upload complete, all files in dataset. Close this window and refresh your dataset page to see the uploaded files.",
-        msgRequiredPatOrFileNameChange: "The highlighted path/file(s) below contain one or more disallowed characters (paths can only contain a-Z, 0-9, '_', '-', '.', '\', '/' and ' ', and filenames cannot contain any of /;:|?*#). Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.",
+        msgRequiredPathOrFileNameChange: "The highlighted path/file(s) below contain one or more disallowed characters (paths can only contain a-Z, 0-9, '_', '-', '.', '\', '/' and ' ', and filenames cannot contain any of /;:|?*#). Disallowed characters will be replaced by an underscore (_) if the file(s) are uploaded.",
     },
     fr: {
         title: "Envoi d'un dossier",
@@ -32,7 +32,7 @@ const translations = {
         msgNoFile: "Aucun fichier à envoyer. Cochez certains fichiers ou rafraîchissez la page pour recommencer.",
         msgUploadCompleteRegistering: "Envois vers S3 terminés. Enregistrement de tous les fichiers en cours dans le jeu de données. Cela peut prendre du temps pour un grand nombre de fichiers.",
         msgUploadComplete: "Envoi terminé, tous les fichiers sont dans le jeu de données. Fermez cette fenêtre et rafraîchissez la page de votre jeu de données pour voir les fichiers envoyés.",
-        msgRequiredFileNameChange: "Les chemins/noms de fichiers en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (les chemins ne peuvent contenir que a-Z, 0-9, '_', '-', '.', '\', '/' et ' ', et les noms de fichiers ne peuvent contenir aucun des éléments suivants : /;:|?*#). Les caractères non autorisés seront remplacés par un trait de soulignement (_) si le(s) fichier(s) sont téléchargés.",
+        msgRequiredPathOrFileNameChange: "Les chemins/noms de fichiers en surbrillance ci-dessous contiennent un ou plusieurs caractères non autorisés (les chemins ne peuvent contenir que a-Z, 0-9, '_', '-', '.', '\', '/' et ' ', et les noms de fichiers ne peuvent contenir aucun des éléments suivants : /;:|?*#). Les caractères non autorisés seront remplacés par un trait de soulignement (_) si le(s) fichier(s) sont téléchargés.",
     },
 };
 


### PR DESCRIPTION
This PR adds checks for valid path and filenames, using regexes based on the rules reported by Dataverse in the server.log. With the PR, these potential errors are caught and the user is warned that disallowed chars will be replaced by _ if the highlighted files are actually selected for upload. That substitution is done if any such files are uploaded. Checks for existing files also handle this substitution, i.e. the check is to see if a file with the changed path/filename exists in the dataset (not just the original/not allowed versions with bad chars).

Closes #21 

In addition to #21, these issues were seen at QDR and we've been testing with our (slight) variant (some styling changes).