### PR TITLE
Update Libraries/Add localinstall script

### DIFF
--- a/localinstall.sh
+++ b/localinstall.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+echo Creating version of DVWebloader that uses only local libraries
+echo Run this script in the directory with the dvwebloader.html file
+
+
+dirLocal=$(pwd)
+
+echo Downloading local copies of remote JavaScript libraries:
+sed -n 's/.*src="\(http[^"]*\)".*/\1/p' *.html | sort -u | sed -n 's/^\(.*\/\)*\(.*\)/sed -i \x27s,\0\,lib\/\2,\x27 *.html/p' > replace_js.sh
+sed -n 's/.*src="\(http[^"]*\)".*/\1/p' *.html | sort -u  > urls_js.txt
+source replace_js.sh
+cat urls_js.txt
+
+echo Downloading local copies of remote JavaScript libraries referenced in js files:
+cd ./js
+sed -n 's/.*src[ ]*=[ ]*"\(http[^"]*\)".*/\1/p' *.js | sort -u | sed -n 's/^\(.*\/\)*\(.*\)/sed -i \x27s,\0\,lib\/\2,\x27 *.js/p' > replacejs_js.sh
+sed -n 's/.*src[ ]*=[ ]*"\(http[^"]*\)".*/\1/p' *.js | sort -u  > urlsjs_js.txt
+source replacejs_js.sh
+cat urlsjs_js.txt
+cd ..
+
+echo Downloading local copies of remote CSS files:
+sed -n 's/.*<link.*href="\(http[^"]*\)".*/\1/p' *.html | sort -u | sed -n 's/^\(.*\/\)*\(.*\)/sed -i \x27s,\0\,lib\/\2,\x27 *.html/p' > replace_css.sh
+sed -n 's/.*<link.*href="\(http[^"]*\)".*/\1/p' *.html | sort -u > urls_css.txt
+source replace_css.sh
+cat urls_css.txt
+
+if [ ! -d ./lib ]; then
+  mkdir ./lib
+fi
+cd ./lib
+while read url; do
+    wget --quiet $url
+done < "../urls_js.txt"
+while read url; do
+    wget --quiet $url
+done < "../js/urlsjs_js.txt"
+
+
+cd ".."
+if [ ! -d ./css ]; then
+  mkdir ./css
+fi
+cd ./css
+while read url; do
+    wget --quiet $url
+done < "../urls_css.txt"
+
+cd ..
+
+
+echo Cleaning Up...
+rm urls_js.txt
+rm urls_css.txt
+rm replace_js.sh
+rm replace_css.sh
+rm js/urlsjs_js.txt
+rm js/replacejs_js.sh
+
+echo Done
+exit 0

--- a/src/dvwebloader.html
+++ b/src/dvwebloader.html
@@ -3,8 +3,8 @@
     <head>
         <title>Dataverse WebLoader</title>
         <link type="text/css" rel="stylesheet" href="css/dvwebloader.css">
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/core.js"></script>
+        <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/core.js"></script>
         <script type="module" src="js/fileupload2.js"></script>
         <script src="js/logoHandler.js"></script>
         

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -82,23 +82,23 @@ $(document).ready(function() {
 
             switch (checksumAlgName) {
                 case 'MD5':
-                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/md5.js";
+                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/md5.js";
                     break;
                 case 'SHA-1':
-                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/sha1.js";
+                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/sha1.js";
                     break;
                 case 'SHA-256':
-                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/sha256.js";
+                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/sha256.js";
                     break;
                 case 'SHA-512':
-                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/x64-core.js";
+                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/x64-core.js";
                     head.appendChild(js);
                     js = document.createElement("script");
                     js.type = "text/javascript";
-                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/sha512.js";
+                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/sha512.js";
                     break;
                 default:
-                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/md5.js";
+                    js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.2.0/md5.js";
             }
             head.appendChild(js);
             retrieveDatasetInfo();


### PR DESCRIPTION
This PR updates the crypto libraries to 4.2.0 as in #25, also updates the jquery library, and adds a localinstall.sh script that can download local copies of all of them and modify the html and javascript to use them.

If/when this is merged, we can decide how to update the Wiki and/or README to indicate a local installation option exists.

The process is to have the localinstall.sh script available,
chmod 755 localinstall.sh
cd to the directory where dvwebloader.html is
../locainstall.sh (using whatever appropriate path to the script)
