### PR TITLE
Fix sha512 async issue

### DIFF
--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -92,10 +92,13 @@ $(document).ready(function() {
                     break;
                 case 'SHA-512':
                     js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/x64-core.js";
+                    //Make async false to avoid sha512 loading before the x64-core which can cause an error
+                    js.async = false;
                     head.appendChild(js);
                     js = document.createElement("script");
                     js.type = "text/javascript";
                     js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/sha512.js";
+                    js.async = false;
                     break;
                 default:
                     js.src = "https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/md5.js";


### PR DESCRIPTION
When using SHA512 hashes in Dataverse, the DVWebloader occasionally threw an error related to the crypto libraries ('Word' or 'create' not found). It looks like this was a race condition in loading the x64-core and sha512 libraries (sha512 is the only one that requires x64-core in addition to the algorithm specific library.)

The fix has been tested at QDR where sha512 is in use. It solves the problem for both remote and local installs (see #28) of the libraries.