### PR TITLE
Update version to 0.3

### DIFF
--- a/src/dvwebloader.html
+++ b/src/dvwebloader.html
@@ -26,7 +26,7 @@
             </div>
             <div id="filelist"></div>
             <div id="credit">
-                <a href='https://github.com/gdcc/dvwebloader' target='_blank'>DVWebloader v0.2</a><span id="sponsor-text">, development sponsored by UiT/DataverseNO</span>
+                <a href='https://github.com/gdcc/dvwebloader' target='_blank'>DVWebloader v0.3</a><span id="sponsor-text">, development sponsored by UiT/DataverseNO</span>
             </div>
             <script>
                 var input = document


### PR DESCRIPTION
So far there hasn't been any release of dvwebloader, with the old version being reported in the UI as v0.2. I suggest that after merging recent PRs (#27, #28, #29, any response to #26 (merged but required additional changes)) that we update to v0.3. 

This version should continue to be compatible with 5.13+ although it does fix an issue with fav icons (the path to get these from Dataverse changes from including javax to including jakarta when we updated to EE10/Payara 6) so that part is now compatible with 6.x rather than 5.13. (It was clearly non-fatal as dvwebloader was working with 6.x before and other than the fav icons, the new version should work with 5.x).

Whether it is also time to create a tag/release is tbd. If someone is interested in doing the work, it probably makes sense, but we could also just leave it live until we decide on a 1.0.