### PR TITLE
Multiple bug fixes

### DIFF
--- a/src/css/dvwebloader.css
+++ b/src/css/dvwebloader.css
@@ -98,3 +98,9 @@ h1 {
    background-color: bisque;
     padding: 10px;
 }
+#content-warnings div.warn {
+   margin: 10px;
+   border-color: chocolate;
+   border-width: 2px;
+   border-style: solid;
+}

--- a/src/dvwebloader.html
+++ b/src/dvwebloader.html
@@ -27,7 +27,7 @@
             </div>
             <div id="filelist"></div>
             <div id="credit">
-                <a href='https://github.com/gdcc/dvwebloader' target='_blank'>DVWebloader v0.3</a><span id="sponsor-text">, development sponsored by UiT/DataverseNO</span>
+                <a href='https://github.com/gdcc/dvwebloader' target='_blank'>DVWebloader v0.4alpha1</a><span id="sponsor-text">, development sponsored by UiT/DataverseNO</span>
             </div>
             <script>
                 var input = document

--- a/src/dvwebloader.html
+++ b/src/dvwebloader.html
@@ -23,6 +23,7 @@
             <div id="top">
                 <label for='files' class='button'><span id="select-dir-text">Select a Directory</span><input type="file" id="files" name="files[]" multiple webkitdirectory style="display: none" /></label>
                 <div id='messages'></div>
+                <div id='content-warnings'></div>
             </div>
             <div id="filelist"></div>
             <div id="credit">

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -327,8 +327,8 @@ async function retrieveDatasetInfo() {
                 let df = entry.dataFile;
                 let convertedFile = false;
                 if (("originalFileFormat" in df)
-                    && (!df.contentType === df.originalFileFormat)) {
-                    console.log("The file named " + df.getString("filename")
+                    && (!(df.contentType === df.originalFileFormat))) {
+                    console.log("The file named " + df.filename
                         + " on the server was created by Dataverse's ingest process from an original uploaded file");
                     convertedFile = true;
                 }
@@ -745,7 +745,7 @@ var fileUpload = class fileUploadClass {
 }
     ;
 function removeExtension(name) {
-    let extIndex = name.indexOf(".");
+    let extIndex = name.lastIndexOf(".");
     let sepIndex = name.indexOf('/');
     if (extIndex > sepIndex) {
         return name.substring(0, extIndex);

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -238,6 +238,17 @@ function addMessage(type, key, ...keyArgs) {
     $('#messages').html('')
         .append($('<div/>').addClass(type).html(msg));
 }
+function addContentWarning(key, ...keyArgs) {
+    let msg = getLocalizedString(dvLocale, key);
+    
+    if(keyArgs && Array.isArray(keyArgs)) {
+        for (var i = 0; i < keyArgs.length; i++) {
+            msg = msg.replaceAll('{'+i+'}',keyArgs[i]);
+        }
+    }
+    $('#content-warnings').html('')
+        .append($('<div/>').addClass('warn').html(msg));
+}
 
 async function populatePageMetadata(data) {
     var mdFields = data.metadataBlocks.citation.fields;
@@ -765,8 +776,8 @@ function queueFileForDirectUpload(file) {
     let path =origPath.substring(0, origPath.length - file.name.length);
     let badPath = (path.match(/^[\w\-\.\\\/ ]*$/)===null);
     if(badPath) {
-      if($('.warn').length==0) {
-        addMessage('warn', 'msgRequiredPathOrFileNameChange');
+      if($('#content-warnings.warn').length==0) {
+        addContentWarning('msgRequiredPathOrFileNameChange');
       }
       //Munge path according to rules
       path = path.replace(/[^\w\-\.\\\/ ]+/g,'_');
@@ -799,8 +810,8 @@ function queueFileForDirectUpload(file) {
     }
     let badChars = !(fUpload.file.name.match(/[:<>;#\/"*|?\\]/)===null);
     if(badChars) {
-      if($('.warn').length==0) {
-          addMessage('warn', 'msgRequiredPathOrFileNameChange');
+      if($('#content-warnings.warn').length==0) {
+          addContentWarning('msgRequiredPathOrFileNameChange');
       }
     }
     row.append($('<input/>').prop('type', 'checkbox').prop('id', 'file_' + fUpload.id).prop('checked', send));

--- a/src/js/fileupload2.js
+++ b/src/js/fileupload2.js
@@ -227,25 +227,26 @@ function initTranslation() {
 function initSpanTxt(htmlId, key) {
     $('#'+htmlId).text(getLocalizedString(dvLocale, key));
 }
-function addMessage(type, key, ...keyArgs) {
+
+function formatMessage(key, keyArgs) {
     let msg = getLocalizedString(dvLocale, key);
     
     if(keyArgs && Array.isArray(keyArgs)) {
         for (var i = 0; i < keyArgs.length; i++) {
-            msg = msg.replaceAll('{'+i+'}',keyArgs[i]);
+            msg = msg.replaceAll('{'+i+'}', keyArgs[i]);
         }
     }
+    return msg;
+}
+
+function addMessage(type, key, ...keyArgs) {
+    let msg = formatMessage(key, keyArgs);
     $('#messages').html('')
         .append($('<div/>').addClass(type).html(msg));
 }
+
 function addContentWarning(key, ...keyArgs) {
-    let msg = getLocalizedString(dvLocale, key);
-    
-    if(keyArgs && Array.isArray(keyArgs)) {
-        for (var i = 0; i < keyArgs.length; i++) {
-            msg = msg.replaceAll('{'+i+'}',keyArgs[i]);
-        }
-    }
+    let msg = formatMessage(key, keyArgs);
     $('#content-warnings').html('')
         .append($('<div/>').addClass('warn').html(msg));
 }

--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -23,6 +23,9 @@ const translations = {
         msgDeselectAll: "Deselect all",
         msgMaxFilesExceeded: "Maximum number of files exceeded. Uncheck some files to enable upload.",
         msgMaxFilesReached: "Maximum number of files reached. Uncheck some files before selecting more.",
+        msgDatasetLocked: "This dataset is currently locked. File uploads are not allowed at this time.",
+        msgDatasetLockedInReview: "This dataset is currently In Review. You are not allowed to upload files at this time.",
+        msgErrorRetrievingDataset: "An error occurred while retrieving dataset information."
     },
     fr: {
         title: "Envoi d'un dossier",
@@ -47,6 +50,9 @@ const translations = {
         msgDeselectAll: "Tout désélectionner",
         msgMaxFilesExceeded: "Nombre maximal de fichiers dépassé. Décochez certains fichiers pour activer le transfert.",
         msgMaxFilesReached: "Nombre maximal de fichiers atteint. Décochez certains fichiers avant d'en sélectionner d'autres.",
+        msgDatasetLocked: "Ce jeu de données est actuellement verrouillé. Les envois de fichiers ne sont pas autorisés pour le moment.",
+        msgDatasetLockedInReview: "Ce jeu de données est actuellement en cours de révision. Vous n'êtes pas autorisé à télécharger des fichiers pour le moment.",
+        msgErrorRetrievingDataset: "Une erreur s'est produite lors de la récupération des informations du jeu de données."
     },
 };
 


### PR DESCRIPTION
This PR fixes two bugs found since the v0.3 release:
- The warning when a file has invalid chars in it's path or name was being overwritten/was not visible
- Detection of original files in the datasets was failing (and therefore the file would be checked by default to be uploaded again.

In addition, the PR has a minor improvement - it checks to see if the dataset is locked and the given user won't be able to upload files. This should be a rare occurrence, since you can't launch the tool if the dataset is locked, but if someone has it open and refreshes the page, their new upload attempt could fail if the dataset became locked (e.g. from ingest not yet completing after a first upload).

Closes #21
Closes #38 
